### PR TITLE
Fixing dead links for automated sbt download

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Parameter | Default value | Description
 `--n` | 5 | N-gram order for text-reuse detection
 `--max-series` | 100 | Maximum document frequency of n-grams used.
 `--min-match` | 5 | Minimum number of matching n-grams between two documents.
-`--relative-overlap` | 0.5 | Proportion that two different aligned passages from the same document must overlap to be clustered together, as measured on the longer passage.
+`--relative-overlap` | 0.8 | Proportion that two different aligned passages from the same document must overlap to be clustered together, as measured on the longer passage.
 
 Pass parameters to the underlying Spark processes using the
 `SPARK_SUBMIT_ARGS` environment variable.  For example, to run passim

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -38,7 +38,9 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
-  URL1=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+#  URL1=https://dl.bintray.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+  URL1="https://github.com/sbt/sbt/releases/download/v"${SBT_VERSION}"/sbt-"${SBT_VERSION}".zip"
+  echo $URL1
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR
@@ -49,10 +51,16 @@ acquire_sbt_jar () {
     # Download
     printf "Attempting to fetch sbt\n"
     JAR_DL="${JAR}.part"
+    ZIP_DL="build/sbt-launch-${SBT_VERSION}.zip"
     if [ $(command -v curl) ]; then
-      curl --fail --location --silent ${URL1} > "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+      curl --fail --location --silent ${URL1} > "${ZIP_DL}" &&\
+      #curl --fail --location --silent ${URL1} > "${JAR_DL}" &&\
+        #mv "${JAR_DL}" "${JAR}"
+        unzip "${ZIP_DL}" -d "build/temp/"
+        mv "build/temp/sbt/bin/sbt-launch.jar" $JAR
+        rm -rf "build/temp/"
     elif [ $(command -v wget) ]; then
+      echo "wget"
       wget --quiet ${URL1} -O "${JAR_DL}" &&\
         mv "${JAR_DL}" "${JAR}"
     else

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -54,15 +54,14 @@ acquire_sbt_jar () {
     ZIP_DL="build/sbt-launch-${SBT_VERSION}.zip"
     if [ $(command -v curl) ]; then
       curl --fail --location --silent ${URL1} > "${ZIP_DL}" &&\
-      #curl --fail --location --silent ${URL1} > "${JAR_DL}" &&\
-        #mv "${JAR_DL}" "${JAR}"
-        unzip "${ZIP_DL}" -d "build/temp/"
+        unzip -qq "${ZIP_DL}" -d "build/temp/"
         mv "build/temp/sbt/bin/sbt-launch.jar" $JAR
         rm -rf "build/temp/"
     elif [ $(command -v wget) ]; then
-      echo "wget"
-      wget --quiet ${URL1} -O "${JAR_DL}" &&\
-        mv "${JAR_DL}" "${JAR}"
+      wget --quiet ${URL1} -O "${ZIP_DL}" &&\
+        unzip -qq "${ZIP_DL}" -d "build/temp/"
+        mv "build/temp/sbt/bin/sbt-launch.jar" $JAR
+        rm -rf "build/temp/"
     else
       printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
       exit -1


### PR DESCRIPTION
Hi @dasmiq,

We (well, @csuire01) pointed out a link was dead in the sbt download script (https://github.com/dasmiq/passim/blob/master/build/sbt-launch-lib.bash#L41). This was discussed here (https://github.com/programminghistorian/ph-submissions/issues/372#issuecomment-875645846).

This PR updates the download link to the new one (GitHub), and accounts for the changes (`jar` --> `zip`). I've tested it in its curl and wget flavours (Ubuntu 20.10 and Ubuntu 21.04 respectively) on clean installs with Java 8, and it behaves as it should.