### PR TITLE
Windows issue fix

### DIFF
--- a/bin/passim.cmd
+++ b/bin/passim.cmd
@@ -1,3 +1,2 @@
 @echo off
-call %~dp0seriatim --all-pairs ^
-  --fields "xxhash64(series)^ as^ gid" -f gid^<gid2 %*
+call %~dp0seriatim --all-pairs --fields "xxhash64(series) as gid" -f gidLESSTHANgid2 %*

--- a/passim/seriatim.py
+++ b/passim/seriatim.py
@@ -597,6 +597,11 @@ def main(args):
     parser.add_argument('outputPath', metavar='<path>', help='output')
     config = parser.parse_args(args)
 
+    # replace placeholders in the filterpairs argument:
+    config.filterpairs = config.filterpairs.replace("LESSTHAN", "<")
+    config.filterpairs = config.filterpairs.replace("GREATERTHAN", ">")
+    config.filterpairs = config.filterpairs.replace("PIPE", "|")
+    
     print(config)
 
     spark = SparkSession.builder.appName('Passim Alignment').getOrCreate()


### PR DESCRIPTION
Fix for issue #13 

Proposed solution: 

1. use quotation marks around "xxhash64(series) as gid" instead of escaping the spaces
2. use a placeholder "LESSTHAN" instead of the less than sign, which is not allowed with CALL, and replace it with the less than character "<" in seriatim.py

Possible improvements: replace less than, greater than and pipe in user-defined arguments with LESSTHAN, GREATERTHAN and PIPE.