### PR TITLE
Restrict pyspark to 3.5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
     ],
     install_requires=[
-        'pyspark>=3.5.1',
+        'pyspark>=3.5.1,<4.0',
         'graphframes',
         'intervaltree'
     ],


### PR DESCRIPTION
Code will fail with pyspark 4.x, this change ensures 3.5.x will be installed.